### PR TITLE
feat: add crvSusd to treasury

### DIFF
--- a/contexts/useTreasury.tsx
+++ b/contexts/useTreasury.tsx
@@ -42,6 +42,7 @@ export const TreasuryContextApp = ({children}: {children: ReactElement}): ReactE
 		const	yvEthContract = new Contract('0xa258C4606Ca8206D8aA700cE2143D7db854D168c', YEARN_VAULT_ABI);
 		const	cvxContract = new Contract('0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B', CVX_ABI);
 		const	crvSusdContract = new Contract('0x22eE18aca7F3Ee920D01F25dA85840D12d98E8Ca', CONVEX_REWARDS_ABI);
+		const	crvSusdExtraRewardsContract = new Contract('0x81fCe3E10D12Da6c7266a1A169c4C96813435263', CONVEX_REWARDS_ABI); //SNX
 
 		const	jobsCalls = [
 			cvxContract.totalSupply(),
@@ -84,7 +85,9 @@ export const TreasuryContextApp = ({children}: {children: ReactElement}): ReactE
 
 			crvSusdContract.balanceOf(process.env.THE_KEEP3R as string),
 			crvSusdContract.earned(process.env.THE_KEEP3R as string),
+			crvSusdExtraRewardsContract.earned(process.env.THE_KEEP3R as string),
 			lensPriceContract.getPriceUsdcRecommended('0xC25a3A3b969415c80451098fa907EC722572917F'),
+			lensPriceContract.getPriceUsdcRecommended('0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'), //SNX
 			
 			yvEthContract.balanceOf(process.env.THE_KEEP3R as string),
 			lensPriceContract.getPriceUsdcRecommended('0xa258C4606Ca8206D8aA700cE2143D7db854D168c'),
@@ -250,7 +253,9 @@ export const TreasuryContextApp = ({children}: {children: ReactElement}): ReactE
 		// crvSUSD //
 		const	crvSUSDStacked = format.units(resultsJobsCall[rIndex++] as BigNumber, 18);
 		const	crvSUSDEarned = resultsJobsCall[rIndex++] as BigNumber;
+		const	crvSUSDExtra0Earned = resultsJobsCall[rIndex++] as BigNumber;
 		const	crvSUSDPrice = format.units(resultsJobsCall[rIndex++] as BigNumber, 6);
+		const	crvSUSDExtra0Price = format.units(resultsJobsCall[rIndex++] as BigNumber, 6); //SNX
 		_treasury.push({
 			name: 'crvSUSD',
 			protocol: 'Convex',
@@ -260,6 +265,8 @@ export const TreasuryContextApp = ({children}: {children: ReactElement}): ReactE
 			unclaimedRewards: Number(crvSUSDEarned),
 			unclaimedRewardsUSD: (
 				Number(format.units(crvSUSDEarned, 18)) * Number(crvPrice)
+				+
+				Number(format.units(crvSUSDExtra0Earned, 18)) * Number(crvSUSDExtra0Price)
 				+
 				Number(format.units(crvSUSDEarned.mul(reduction).div(cvxTotalCliffs), 18)) * Number(cvxPrice)
 			)


### PR DESCRIPTION
Add `crvSUSD` support for treasury with theses addresses:
- `0x22eE18aca7F3Ee920D01F25dA85840D12d98E8Ca` for stacking (balance + earned)
- `0xC25a3A3b969415c80451098fa907EC722572917F` for token price via lens