### PR TITLE
refactor(registry): move registry to json file

### DIFF
--- a/utils/registry.json
+++ b/utils/registry.json
@@ -1,0 +1,74 @@
+{
+	"0x28937B751050FcFd47Fd49165C6E1268c296BA19": {
+		"chainID": 1,
+		"address": "0x28937B751050FcFd47Fd49165C6E1268c296BA19",
+		"name": "MakerDAOUpkeep",
+		"repository": "https://github.com/defi-wonderland/keep3r-cli-job-maker"
+	},
+	"0x5D469E1ef75507b0E0439667ae45e280b9D81B9C": {
+		"chainID": 1,
+		"address": "0x5D469E1ef75507b0E0439667ae45e280b9D81B9C",
+		"name": "MakerDAOUpkeep",
+		"repository": "https://github.com/defi-wonderland/keep3r-cli-job-maker"
+	},
+	"0x62496bDF47De3c07e12F84a20681426AbCC618e2": {
+		"chainID": 1,
+		"address": "0x62496bDF47De3c07e12F84a20681426AbCC618e2",
+		"name": "DCAKeep3rJob",
+		"repository": "https://github.com/Mean-Finance/keep3r-script"
+	},
+	"0x220a85bCd2212ab0b27EFd0de8b5e03175f0adee": {
+		"chainID": 1,
+		"address": "0x220a85bCd2212ab0b27EFd0de8b5e03175f0adee",
+		"name": "YearnHarvestV2",
+		"repository": "https://github.com/defi-wonderland/yearn-keeper-scripts"
+	},
+	"0xE6DD4B94B0143142E6d7ef3110029c1dcE8215cb": {
+		"chainID": 1,
+		"address": "0xE6DD4B94B0143142E6d7ef3110029c1dcE8215cb",
+		"name": "YearnHarvestV2",
+		"repository": "https://github.com/defi-wonderland/yearn-keeper-scripts"
+	},
+	"0xdeE991cbF8527A33E84a2aAb8a65d68D5D591bAa": {
+		"chainID": 1,
+		"address": "0xdeE991cbF8527A33E84a2aAb8a65d68D5D591bAa",
+		"name": "YearnTendV2",
+		"repository": "https://github.com/defi-wonderland/yearn-keeper-scripts"
+	},
+	"0xcD7f72F12c4b87dAbd31d3aa478A1381150c32b3": {
+		"chainID": 1,
+		"address": "0xcD7f72F12c4b87dAbd31d3aa478A1381150c32b3",
+		"name": "YearnTendV2",
+		"repository": "https://github.com/defi-wonderland/yearn-keeper-scripts"
+	},
+	"0x656027367B5e27dC21984B546e64dC24dBFaA187": {
+		"chainID": 1,
+		"address": "0x656027367B5e27dC21984B546e64dC24dBFaA187",
+		"name": "PhutureRebalancing",
+		"repository": "https://github.com/Phuture-Finance/keep3r-cli-job-phuture"
+	},
+	"0xa61d82a9127B1c1a34Ce03879A068Af5b786C835": {
+		"chainID": 1,
+		"address": "0xa61d82a9127B1c1a34Ce03879A068Af5b786C835",
+		"name": "PhutureDepositManager",
+		"repository":"https://github.com/Phuture-Finance/keep3r-cli-deposit-manager-job"
+	},
+	"0xEC771dc7Bd0aA67a10b1aF124B9b9a0DC4aF5F9B": {
+		"chainID": 1,
+		"address": "0xEC771dc7Bd0aA67a10b1aF124B9b9a0DC4aF5F9B",
+		"name": "PhutureHarvesting",
+		"repository": "https://github.com/Phuture-Finance/keep3r-cli-job-phuture-savings-vault"
+	},
+	"0x553591d6eac7A127dE36063a1b6cD31D2FB9E42d": {
+		"chainID": 1,
+		"address": "0x553591d6eac7A127dE36063a1b6cD31D2FB9E42d",
+		"name": "SidechainOracles Job",
+		"repository": "https://github.com/defi-wonderland/sidechain-oracles-keeper-scripts"
+	},
+	"0xe74379Ed6e94C85dA90d27B92DF670DB282995af": {
+		"chainID": 1,
+		"address": "0xe74379Ed6e94C85dA90d27B92DF670DB282995af",
+		"name": "GrizzlyHarvest",
+		"repository": "https://github.com/borus-dev/grizzly-keeper-scripts"
+	}
+}

--- a/utils/registry.tsx
+++ b/utils/registry.tsx
@@ -1,3 +1,5 @@
+import UNTYPED_REGISTRY from './registry.json';
+
 type	TRegistry = {
 	[key: string]: {
 		chainID: number,
@@ -6,80 +8,8 @@ type	TRegistry = {
 		repository: string
 	};
 }
-const	REGISTRY: TRegistry = {
-	'0x28937B751050FcFd47Fd49165C6E1268c296BA19': {
-		chainID: 1,
-		address: '0x28937B751050FcFd47Fd49165C6E1268c296BA19',
-		name: 'MakerDAOUpkeep',
-		repository: 'https://github.com/defi-wonderland/keep3r-cli-job-maker'
-	},
-	'0x5D469E1ef75507b0E0439667ae45e280b9D81B9C': {
-		chainID: 1,
-		address: '0x5D469E1ef75507b0E0439667ae45e280b9D81B9C',
-		name: 'MakerDAOUpkeep',
-		repository: 'https://github.com/defi-wonderland/keep3r-cli-job-maker'
-	},
-	'0x62496bDF47De3c07e12F84a20681426AbCC618e2': {
-		chainID: 1,
-		address: '0x62496bDF47De3c07e12F84a20681426AbCC618e2',
-		name: 'DCAKeep3rJob',
-		repository: 'https://github.com/Mean-Finance/keep3r-script'
-	},
-	'0x220a85bCd2212ab0b27EFd0de8b5e03175f0adee': {
-		chainID: 1,
-		address: '0x220a85bCd2212ab0b27EFd0de8b5e03175f0adee',
-		name: 'YearnHarvestV2',
-		repository: 'https://github.com/defi-wonderland/yearn-keeper-scripts'
-	},
-	'0xE6DD4B94B0143142E6d7ef3110029c1dcE8215cb': {
-		chainID: 1,
-		address: '0xE6DD4B94B0143142E6d7ef3110029c1dcE8215cb',
-		name: 'YearnHarvestV2',
-		repository: 'https://github.com/defi-wonderland/yearn-keeper-scripts'
-	},
-	'0xdeE991cbF8527A33E84a2aAb8a65d68D5D591bAa': {
-		chainID: 1,
-		address: '0xdeE991cbF8527A33E84a2aAb8a65d68D5D591bAa',
-		name: 'YearnTendV2',
-		repository: 'https://github.com/defi-wonderland/yearn-keeper-scripts'
-	},
-	'0xcD7f72F12c4b87dAbd31d3aa478A1381150c32b3': {
-		chainID: 1,
-		address: '0xcD7f72F12c4b87dAbd31d3aa478A1381150c32b3',
-		name: 'YearnTendV2',
-		repository: 'https://github.com/defi-wonderland/yearn-keeper-scripts'
-	},
-	'0x656027367B5e27dC21984B546e64dC24dBFaA187': {
-		chainID: 1,
-		address: '0x656027367B5e27dC21984B546e64dC24dBFaA187',
-		name: 'PhutureRebalancing',
-		repository: 'https://github.com/Phuture-Finance/keep3r-cli-job-phuture'
-	},
-	'0xa61d82a9127B1c1a34Ce03879A068Af5b786C835': {
-		chainID: 1,
-		address: '0xa61d82a9127B1c1a34Ce03879A068Af5b786C835',
-		name: 'PhutureDepositManager',
-		repository:'https://github.com/Phuture-Finance/keep3r-cli-deposit-manager-job'
-	},
-	'0xEC771dc7Bd0aA67a10b1aF124B9b9a0DC4aF5F9B': {
-		chainID: 1,
-		address: '0xEC771dc7Bd0aA67a10b1aF124B9b9a0DC4aF5F9B',
-		name: 'PhutureHarvesting',
-		repository: 'https://github.com/Phuture-Finance/keep3r-cli-job-phuture-savings-vault'
-	},
-	'0x553591d6eac7A127dE36063a1b6cD31D2FB9E42d': {
-		chainID: 1,
-		address: '0x553591d6eac7A127dE36063a1b6cD31D2FB9E42d',
-		name: 'SidechainOracles Job',
-		repository: 'https://github.com/defi-wonderland/sidechain-oracles-keeper-scripts'
-	},
-	'0xe74379Ed6e94C85dA90d27B92DF670DB282995af': {
-		chainID: 1,
-		address: '0xe74379Ed6e94C85dA90d27B92DF670DB282995af',
-		name: 'GrizzlyHarvest',
-		repository: 'https://github.com/borus-dev/grizzly-keeper-scripts'
-	}
-};
+
+const REGISTRY = UNTYPED_REGISTRY as TRegistry;
 
 export type {TRegistry};
 export default REGISTRY;


### PR DESCRIPTION
This PR moves the registry that is currently in `registry.tsx` into a `registry.json` file.

This will allow external integrations to actually query for the Jobs names to be displayed correctly. An example for this is the Zapper integration that is currently live, as of now all jobs appear as "Keep3r Job", with this change we could query the json file directly from the zapper studio integration and display the jobs on the zapper dashboard with the correct names for each job.

<img width="981" alt="Screenshot 2022-12-28 at 11 15 23" src="https://user-images.githubusercontent.com/94012134/209825458-10ad8fa2-fbfd-42ae-8820-9e6b96bb961d.png">
